### PR TITLE
Fixing deprecated function, build_navigation().

### DIFF
--- a/calendar.php
+++ b/calendar.php
@@ -16,12 +16,12 @@
 
 /**
  * calendar.php
- * 
+ *
  * @package    ilios
  * @copyright  &copy; 2014 The Regents of the University of California
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  * @author     Carson Tam (carson.tam@ucsf.edu), UC San Francisco
- * 
+ *
  */
 
 require_once('../../config.php');
@@ -29,6 +29,7 @@ require_once('../../config.php');
 $moodle_header = strtolower(optional_param('moodle_header', 'false', PARAM_TEXT));
 $iframe_width = optional_param('iframe_width', '100%', PARAM_TEXT);
 $iframe_height = optional_param('iframe_height', '100%', PARAM_TEXT);
+$iframe_style = "width: $iframe_width; height: $iframe_height; ";
 
 $content_url = get_config('ilios','Server_URL');
 $content_url .= get_config('ilios', 'Embedded_Dashboard_Path');
@@ -39,26 +40,29 @@ if (!empty($url_params)) {
 }
 
 if ($moodle_header == 'true' or $moodle_header == 'yes') {
+
     $strcalendar = get_string('ilioscalendartitle', 'block_ilios');
 
-    $urlcalendar = basename(__FILE__);
-    $navlinks = array();
-    $navlinks[] = array('name' => $strcalendar,
-                        'link' => $urlcalendar,
-                        'type' => 'misc');
+    $urlcalendar = new moodle_url("/blocks/ilios/". basename(__FILE__));
 
-    $navigation = build_navigation($navlinks);
-    $site = get_site();
+    $context = context_system::instance();
+    $PAGE->set_context($context);
+    $PAGE->set_url($urlcalendar);
+    $PAGE->set_pagelayout('base');
+    $PAGE->navbar->add($strcalendar);
 
-    print_header("$site->shortname: $strcalendar", $strcalendar, $navigation,
-                 '', '', true, '', user_login_string($site));
+    $PAGE->set_title($SITE->fullname.": ". $strcalendar);
+    $PAGE->set_heading($SITE->fullname);
+
+    // When included moodle header, the iframe_height percentage doesn't have any effect...so set a min-height for now.
+    $iframe_style = "width: $iframe_width; height: $iframe_height; min-height: 420px;";
+    echo $OUTPUT->header();
 }
-
-echo "<iframe frameborder='0' width=\"".$iframe_width.'" height="'.$iframe_height.'" src="'.$content_url.'" >';
+echo "<iframe frameborder='0' src='$content_url' style='$iframe_style'>";
 echo '  <p>Your browser does not support iframe.</p>';
 echo '</iframe>';
 
 if ($moodle_header == 'true' or $moodle_header == 'yes') {
-    print_footer();
+    echo $OUTPUT->footer();
 }
 


### PR DESCRIPTION
Our developer is making the final adjustments to the theme and has come across an challenge with the Ilios calendar block in Moodle version 2.6.x.
It seems that the latest version of this block is made for Moodle 2.0 (or so) and some of the functions used in block are supported until Moodle 2.5.
When we install and work with the block we get the debugging messages below. Have you encountered this error before with testing the block on 2.6 or is there a different version we should use?
I think once the Ilios calendar is working correctly it will not take long to make the theme responsive to it.
Coding error detected, it must be fixed by a programmer: user_login_info() cant be used anymore. User login info is now handled via themes layouts.
More information about this error
Debug info: 
Error code: codingerror
Stack trace:
- line 1343 of /lib/deprecatedlib.php: coding_exception thrown
- line 54 of /blocks/ilios/calendar.php: call to user_login_string()
  Output buffer: 

```
<div class="notifytiny debuggingmessage" data-rel="debugging">build_navigation() is deprecated, please use $PAGE->navbar methods instead.
  <ul style="text-align: left" data-rel="backtrace">
    <li>line 1988 of /lib/deprecatedlib.php: call to debugging()</li>
    <li>line 50 of /blocks/ilios/calendar.php: call to build_navigation()</li>
  </ul>
</div>
```

In Moodle 2.6 they are removed and not available. Please find below debugging message.
Benjamin Young
Director, Application Services
Certified Moodle Course Creator
Self-Service Support Knowledge Base: techsupport.lambdasolutions.net
