### PR TITLE
Reconfigure Ilios URLs

### DIFF
--- a/block_ilios.php
+++ b/block_ilios.php
@@ -49,8 +49,8 @@ class block_ilios extends block_base {
 
         $this->content = new stdClass;
 
-        $ilios_server_link = get_config('ilios', 'Server_URL');
-        $ilios_server_link .= get_config('ilios', 'Dashboard_Path');
+
+        $ilios_dasboard_link = get_config('ilios', 'Dashboard_URL');
 
         $ilios_calendar_link = $CFG->wwwroot.'/blocks/ilios/calendar.php';
         $ilios_calendar_params = get_config('ilios', 'Calendar_Params');
@@ -58,7 +58,7 @@ class block_ilios extends block_base {
             $ilios_calendar_link .= '?'. $ilios_calendar_params;
         }
 
-        $this->content->text = '<a href="'.$ilios_server_link.'" target="_blank">';
+        $this->content->text = '<a href="'.$ilios_dasboard_link.'" target="_blank">';
         $this->content->text .= 'Go to Ilios Dashboard</a><br />';
         $this->content->text .= '<a href="'.$ilios_calendar_link.'">Go to Ilios Calendar</a><br />';
 

--- a/block_ilios.php
+++ b/block_ilios.php
@@ -50,7 +50,7 @@ class block_ilios extends block_base {
         $this->content = new stdClass;
 
 
-        $ilios_dasboard_link = get_config('ilios', 'Dashboard_URL');
+        $ilios_dashboard_link = get_config('ilios', 'Dashboard_URL');
 
         $ilios_calendar_link = $CFG->wwwroot.'/blocks/ilios/calendar.php';
         $ilios_calendar_params = get_config('ilios', 'Calendar_Params');
@@ -58,7 +58,7 @@ class block_ilios extends block_base {
             $ilios_calendar_link .= '?'. $ilios_calendar_params;
         }
 
-        $this->content->text = '<a href="'.$ilios_dasboard_link.'" target="_blank">';
+        $this->content->text = '<a href="'.$ilios_dashboard_link.'" target="_blank">';
         $this->content->text .= 'Go to Ilios Dashboard</a><br />';
         $this->content->text .= '<a href="'.$ilios_calendar_link.'">Go to Ilios Calendar</a><br />';
 

--- a/calendar.php
+++ b/calendar.php
@@ -31,8 +31,7 @@ $iframe_width = optional_param('iframe_width', '100%', PARAM_TEXT);
 $iframe_height = optional_param('iframe_height', '100%', PARAM_TEXT);
 $iframe_style = "width: $iframe_width; height: $iframe_height; ";
 
-$content_url = get_config('ilios','Server_URL');
-$content_url .= get_config('ilios', 'Embedded_Dashboard_Path');
+$content_url = get_config('ilios','Calendar_URL');
 
 $url_params = get_config('ilios', 'Embedded_Dashboard_Params');
 if (!empty($url_params)) {

--- a/lang/en/block_ilios.php
+++ b/lang/en/block_ilios.php
@@ -31,12 +31,10 @@ $string['ilioscalendartitle'] = 'Ilios calendar';
 $string['iliosblocktitle'] = 'Ilios Calendar';
 
 // settings.php
-$string['iliosserverurl'] = 'Ilios Server';
-$string['iliosserverurldescription'] = 'The URL for the Ilios server including the Ilios root virtual directory.';
-$string['iliosdashboardpath'] = 'Ilios Dashboard';
-$string['iliosdashboardpathdescription'] = 'Location path to Ilios dashboard.';
-$string['iliosembeddeddashboardpath'] = 'Ilios Embedded Dashboard';
-$string['iliosembeddeddashboardpathdescription'] = 'Location path to Ilios embedded dashboard.';
+$string['iliosdashboardurl'] = 'Ilios Dashboard';
+$string['iliosserverurldescription'] = 'The absolute URL to the Ilios dashboard.';
+$string['ilioscalendarurl'] = 'Ilios Calendar URL';
+$string['ilioscalendarurldescription'] = 'The absolute URL to the Ilios calendar.';
 $string['iliosembeddeddashboardparams'] = 'Embedded Dashboard Options';
 $string['iliosembeddeddashboardparamsdescription'] = 'Additional parameters for Ilios embedded dashboard.';
 $string['ilioscalendarparams'] = 'Ilios Calendar Options';

--- a/lang/en/block_ilios.php
+++ b/lang/en/block_ilios.php
@@ -32,7 +32,7 @@ $string['iliosblocktitle'] = 'Ilios Calendar';
 
 // settings.php
 $string['iliosdashboardurl'] = 'Ilios Dashboard';
-$string['iliosserverurldescription'] = 'The absolute URL to the Ilios dashboard.';
+$string['iliosdashboardurldescription'] = 'The absolute URL to the Ilios dashboard.';
 $string['ilioscalendarurl'] = 'Ilios Calendar URL';
 $string['ilioscalendarurldescription'] = 'The absolute URL to the Ilios calendar.';
 $string['iliosembeddeddashboardparams'] = 'Embedded Dashboard Options';

--- a/settings.php
+++ b/settings.php
@@ -24,18 +24,14 @@
  * 
  */
 
-$settings->add(new admin_setting_configtext('ilios/Server_URL',
-                                            get_string('iliosserverurl', 'block_ilios'),
-                                            get_string('iliosserverurldescription', 'block_ilios'),
-                                            'https://www.youriliosdomain.com'));
-$settings->add(new admin_setting_configtext('ilios/Dashboard_Path',
-                                            get_string('iliosdashboardpath', 'block_ilios'),
-                                            get_string('iliosdashboardpathdescription', 'block_ilios'),
-                                            '/ilios.php/dashboard_controller'));
-$settings->add(new admin_setting_configtext('ilios/Embedded_Dashboard_Path',
-                                            get_string('iliosembeddeddashboardpath', 'block_ilios'),
-                                            get_string('iliosembeddeddashboardpathdescription', 'block_ilios'),
-                                            '/ilios.php/calendar_controller'));
+$settings->add(new admin_setting_configtext('ilios/Dashboard_URL',
+                                            get_string('iliosdashboardurl', 'block_ilios'),
+                                            get_string('iliosdashboardurldescription', 'block_ilios'),
+                                            'https://www.youriliosdomain.com/ilios.php/dashboard_controller'));
+$settings->add(new admin_setting_configtext('ilios/Embedded_Calendar_URL',
+                                            get_string('ilioscalendarurl', 'block_ilios'),
+                                            get_string('ilioscalendarurldescription', 'block_ilios'),
+                                            'https://www.youriliosdomain.com/ilios.php/calendar_controller'));
 $settings->add(new admin_setting_configtext('ilios/Embedded_Dashboard_Params',
                                             get_string('iliosembeddeddashboardparams', 'block_ilios'),
                                             get_string('iliosembeddeddashboardparamsdescription', 'block_ilios'),

--- a/version.php
+++ b/version.php
@@ -24,6 +24,6 @@
  *
  */
 
-$plugin->version   = 2016062000;
+$plugin->version   = 2016062001;
 $plugin->requires  = 2010112400;  //YYYYMMDDHH (This is the release version of Moodle 2.0)
 $plugin->component = 'block_ilios';


### PR DESCRIPTION
This is in preparation of the upcoming Ilios3 launch.

Since we will ship a standalone calendar app to replace the stripped-down calendar view from Ilios3, we must have the ability to specify a full URL to it, since it will be hosted under a different domain name than the full Ilios application/Dashboard.

Therefore, the block configuration has to change.